### PR TITLE
reordered write/read operations to respond more quickly to client disconnect

### DIFF
--- a/03_chat/chat.go
+++ b/03_chat/chat.go
@@ -91,8 +91,8 @@ func handleConnection(c net.Conn, msgchan chan<- string, addchan chan<- Client, 
 	msgchan <- fmt.Sprintf("New user %s has joined the chat room.\n", client.nickname)
 
 	// I/O
-	go client.ReadLinesInto(msgchan)
-	client.WriteLinesFrom(client.ch)
+	go client.WriteLinesFrom(client.ch)
+	client.ReadLinesInto(msgchan)
 }
 
 func handleMessages(msgchan <-chan string, addchan <-chan Client, rmchan <-chan Client) {


### PR DESCRIPTION
The original order only responded to a client disconnect when the server attempted to write to the connection, which could be minutes or longer. This new order of WriteLinesFrom followed by ReadLinesInto responds to a client disconnect instantly.
